### PR TITLE
[risk=no] Improve round-tripping of BQ schemas

### DIFF
--- a/modules/workbench/modules/reporting/assets/schemas/user.json
+++ b/modules/workbench/modules/reporting/assets/schemas/user.json
@@ -126,7 +126,7 @@
   },
   {
     "name": "free_tier_credits_limit_dollars_override",
-    "type": "FLOAT64",
+    "type": "FLOAT",
     "description": "Override value for the default free tier spending limit (USD).",
     "mode": "NULLABLE"
   },

--- a/modules/workbench/modules/reporting/assets/schemas/workspace.json
+++ b/modules/workbench/modules/reporting/assets/schemas/workspace.json
@@ -203,15 +203,15 @@
     "mode": "NULLABLE"
   },
   {
-    "name": "pre_packaged_concept_set",
-    "type": "INTEGER",
-    "description": "deprecated",
-    "mode": "NULLABLE"
-  },
-  {
     "name": "workspace_id",
     "type": "INTEGER",
     "description": "Primary key of the workspace table in Workrbench application database. Along with\nsnapshot_timestamp, serves as a pseudo-primary key for this table.",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "pre_packaged_concept_set",
+    "type": "INTEGER",
+    "description": "deprecated",
     "mode": "NULLABLE"
   },
   {

--- a/modules/workbench/modules/reporting/assets/schemas/workspace_free_tier_usage.json
+++ b/modules/workbench/modules/reporting/assets/schemas/workspace_free_tier_usage.json
@@ -6,17 +6,20 @@
   },
   {
     "name": "cost",
-    "type": "FLOAT64",
-    "description": "Free tier usage cost for this workspace."
+    "type": "FLOAT",
+    "description": "Free tier usage cost for this workspace.",
+    "mode": "NULLABLE"
   },
   {
     "name": "user_id",
     "type": "INTEGER",
-    "description": "ID of the user whose free tier quota was billed for this workspace."
+    "description": "ID of the user whose free tier quota was billed for this workspace.",
+    "mode": "NULLABLE"
   },
   {
     "name": "workspace_id",
     "type": "INTEGER",
-    "description": "ID of the workspace associated with this free tier cost."
+    "description": "ID of the workspace associated with this free tier cost.",
+    "mode": "NULLABLE"
   }
 ]


### PR DESCRIPTION
- `FLOAT64` -> `FLOAT`
- Order of `pre_packaged_concept_set_id` to reflect existing order
- Some nullability changes on `workspace_free_tier_usage` for consistency, though the nullable issues are being addressed in the provider.