### PR TITLE
[no ticket][risk=low]: Remove useless outputs

### DIFF
--- a/modules/workbench/outputs.tf
+++ b/modules/workbench/outputs.tf
@@ -14,21 +14,3 @@ output "table_names" {
 output "egress_alert_rendered_queries" {
   value = module.egress_detection.egress_alert_rendered_queries
 }
-
-# Monitoring
-output "logging_metric_id_to_name" {
-  description = "The generated logging metric id to logging metric name map"
-  value = module.monitoring.logging_metric_id_to_name
-}
-output "monitoring_metric_id_to_name" {
-  description = "The generated monitoring metric id to monitoring metric name map"
-  value = module.monitoring.monitoring_metric_id_to_name
-}
-output "policy_id_to_name" {
-  description = "The generated policy id to policy name map"
-  value = module.monitoring.policy_id_to_name
-}
-output "dashboard_id_to_json" {
-  description = "The generated dashboard id to json input"
-  value = module.monitoring.dashboard_id_to_json
-}


### PR DESCRIPTION
There are too many things printed out in my console, and I don't think those maps are helpful at all.  