### PR TITLE
[no ticket][risk=log]: Allow monitoring module to use different GCP project

### DIFF
--- a/modules/workbench/main.tf
+++ b/modules/workbench/main.tf
@@ -14,7 +14,7 @@ module "reporting" {
 # GCP Monitoring
 module "monitoring" {
   source = "./modules/monitoring"
-  project_id = var.project_id
+  project_id = var.monitoring_project_id
   notification_channel_id = var.notification_channel_id
   expected_instance_count = var.expected_instance_count
   aou_env = var.aou_env

--- a/modules/workbench/main.tf
+++ b/modules/workbench/main.tf
@@ -14,7 +14,7 @@ module "reporting" {
 # GCP Monitoring
 module "monitoring" {
   source = "./modules/monitoring"
-  project_id = var.monitoring_project_id
+  project_id = local.monitoring_project_id
   notification_channel_id = var.notification_channel_id
   expected_instance_count = var.expected_instance_count
   aou_env = var.aou_env

--- a/modules/workbench/variables.tf
+++ b/modules/workbench/variables.tf
@@ -1,5 +1,5 @@
 locals {
-  monitoring_project_id = var.monitoring_project_id == null ? var.project_id : monitoring_project_id
+  monitoring_project_id = var.monitoring_project_id == null ? var.project_id : var.monitoring_project_id
 }
 
 #

--- a/modules/workbench/variables.tf
+++ b/modules/workbench/variables.tf
@@ -27,6 +27,12 @@ variable "zone" {
   default     = "us-central1-c"
 }
 
+variable monitoring_project_id {
+  description = "GCP Project to create alerts&dashboard&metrics within"
+  type        = string
+  default     = var.project_id
+}
+
 #
 # Reporting
 #

--- a/modules/workbench/variables.tf
+++ b/modules/workbench/variables.tf
@@ -32,7 +32,7 @@ variable "zone" {
 }
 
 variable monitoring_project_id {
-  description = "GCP Project to create alerts&dashboard&metrics within"
+  description = "GCP Project to create alerts, dashboards and metrics within"
   type        = string
   default     = null
 }

--- a/modules/workbench/variables.tf
+++ b/modules/workbench/variables.tf
@@ -1,3 +1,7 @@
+locals {
+  monitoring_project_id = var.monitoring_project_id == null ? var.project_id : monitoring_project_id
+}
+
 #
 # Environment Variables
 #
@@ -30,7 +34,7 @@ variable "zone" {
 variable monitoring_project_id {
   description = "GCP Project to create alerts&dashboard&metrics within"
   type        = string
-  default     = var.project_id
+  default     = null
 }
 
 #


### PR DESCRIPTION
Context: we want  monitoring modules for `local` to be created in different project instead of the same project as `test`.