### PR TITLE
[risk=no][RW-6881] Deprecate 3 user fields in the WRD

### DIFF
--- a/modules/workbench/modules/reporting/assets/schemas/user.json
+++ b/modules/workbench/modules/reporting/assets/schemas/user.json
@@ -7,7 +7,7 @@
   {
     "name": "about_you",
     "type": "STRING",
-    "description": "User's description of  their research background, experience and research interests.",
+    "description": "DEPRECATED - has not been collected for a long time.  Was: user's description of their research background, experience and research interests.",
     "mode": "NULLABLE"
   },
   {
@@ -49,7 +49,7 @@
   {
     "name": "current_position",
     "type": "STRING",
-    "description": "User's current role/position.",
+    "description": "DEPRECATED - has not been collected for a long time.  Was: User's current role/position.",
     "mode": "NULLABLE"
   },
   {
@@ -121,7 +121,7 @@
   {
     "name": "free_tier_credits_limit_days_override",
     "type": "INTEGER",
-    "description": "Override value for the default free tier time limit (days).",
+    "description": "DEPRECATED - there is no longer a time limit associated with free credits.  Was: Override value for the default free tier time limit (days).",
     "mode": "NULLABLE"
   },
   {

--- a/modules/workbench/modules/reporting/assets/schemas/user.json
+++ b/modules/workbench/modules/reporting/assets/schemas/user.json
@@ -7,7 +7,7 @@
   {
     "name": "about_you",
     "type": "STRING",
-    "description": "DEPRECATED - has not been collected for a long time.  Was: user's description of their research background, experience and research interests.",
+    "description": "[DELETED] Was: User's description of their research background, experience and research interests.",
     "mode": "NULLABLE"
   },
   {
@@ -31,7 +31,7 @@
   {
     "name": "compliance_training_expiration_time",
     "type": "TIMESTAMP",
-    "description": "Time  User's compliance training will expire, or null if training not taken or if bypassed",
+    "description": "Time User's compliance training will expire, or null if training not taken or if bypassed",
     "mode": "NULLABLE"
   },
   {
@@ -49,13 +49,13 @@
   {
     "name": "current_position",
     "type": "STRING",
-    "description": "DEPRECATED - has not been collected for a long time.  Was: User's current role/position.",
+    "description": "[DELETED] Was: User's current role/position.",
     "mode": "NULLABLE"
   },
   {
     "name": "data_access_level",
     "type": "STRING",
-    "description": "DEPRECATED - use access_tier_short_names.  An indication of whether the user has completed the requirements for access to the\nregistered tier.",
+    "description": "[DELETED - use access_tier_short_names] Was: An indication of whether the user has completed the requirements for access to the\nregistered tier.",
     "mode": "NULLABLE"
   },
   {
@@ -121,7 +121,7 @@
   {
     "name": "free_tier_credits_limit_days_override",
     "type": "INTEGER",
-    "description": "DEPRECATED - there is no longer a time limit associated with free credits.  Was: Override value for the default free tier time limit (days).",
+    "description": "[DELETED] Was: Override value for the default free tier time limit (days).",
     "mode": "NULLABLE"
   },
   {

--- a/modules/workbench/modules/reporting/assets/schemas/workspace.json
+++ b/modules/workbench/modules/reporting/assets/schemas/workspace.json
@@ -103,7 +103,7 @@
   {
     "name": "rp_control_set",
     "type": "BOOLEAN",
-    "description": "Reserch Control selected. All of Us data will be used as a reference or control\ndataset for comparison with another dataset from a different resource (e.g.\nCase-control studies).",
+    "description": "Research Control selected. All of Us data will be used as a reference or control\ndataset for comparison with another dataset from a different resource (e.g.\nCase-control studies).",
     "mode": "NULLABLE"
   },
   {
@@ -115,7 +115,7 @@
   {
     "name": "rp_disease_of_focus",
     "type": "STRING",
-    "description": "For workspaces that include Disese-focused Research, the user-supplied name of the diseas\nof focus (in the Name of Disease field).",
+    "description": "For workspaces that include Diseese-focused Research, the user-supplied name of the disease\nof focus (in the Name of Disease field).",
     "mode": "NULLABLE"
   },
   {
@@ -181,7 +181,7 @@
   {
     "name": "rp_review_requested",
     "type": "BOOLEAN",
-    "description": "If true, a reivew has been requested by the Resource Access Board. This\nflag is currently not reset when a review is completed.",
+    "description": "If true, a review has been requested by the Resource Access Board. This\nflag is currently not reset when a review is completed.",
     "mode": "NULLABLE"
   },
   {

--- a/modules/workbench/modules/reporting/assets/schemas/workspace.json
+++ b/modules/workbench/modules/reporting/assets/schemas/workspace.json
@@ -115,7 +115,7 @@
   {
     "name": "rp_disease_of_focus",
     "type": "STRING",
-    "description": "For workspaces that include Diseese-focused Research, the user-supplied name of the disease\nof focus (in the Name of Disease field).",
+    "description": "For workspaces that include Disease-focused Research, the user-supplied name of the disease\nof focus (in the Name of Disease field).",
     "mode": "NULLABLE"
   },
   {


### PR DESCRIPTION
We can't actually remove columns, so this is our best alternative.

Also some minor cleanup.

Tested locally by
* terraform-apply'ing this temporary change https://github.com/all-of-us/workbench-devops/pull/81 
* running the reporting cron against localhost
* viewing the results inBigQuery as my PMI-OPS user: https://console.cloud.google.com/bigquery?project=all-of-us-workbench-test&ws=!1m5!1m4!4m3!1sall-of-us-workbench-test!2sreporting_local!3suser&page=table&d=reporting_local&p=all-of-us-workbench-test&t=user

The RW PR https://github.com/all-of-us/workbench/pull/5180 stops populating these fields.  This shouldn't make a difference because they should all have been NULL already.