### PR TITLE
[risk=no][RW-6972] mark user.compliance_training_expiration_time as deleted

### DIFF
--- a/modules/workbench/modules/reporting/assets/schemas/user.json
+++ b/modules/workbench/modules/reporting/assets/schemas/user.json
@@ -31,7 +31,7 @@
   {
     "name": "compliance_training_expiration_time",
     "type": "TIMESTAMP",
-    "description": "Time User's compliance training will expire, or null if training not taken or if bypassed",
+    "description": "[DELETED] Was: Time User's compliance training will expire, or null if training not taken or if bypassed",
     "mode": "NULLABLE"
   },
   {


### PR DESCRIPTION
Matches code change in https://github.com/all-of-us/workbench/pull/5931 - can be merged in either order