### PR TITLE
[RW-8989][risk=no] Update dashboard config to match current infrastructure

### DIFF
--- a/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/cron_jobs.json
+++ b/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/cron_jobs.json
@@ -24,7 +24,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -64,7 +65,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -104,7 +106,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "${metric__labels__name} ${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -144,7 +147,8 @@
                             },
                             "plotType": "STACKED_AREA",
                             "legendTemplate": "${metric__labels__name} ${metric__labels__status} ${metric__labels__requestId}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -184,7 +188,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__name} ${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -218,7 +223,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -252,7 +258,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -286,7 +293,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -320,7 +328,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -354,7 +363,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -388,7 +398,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -422,7 +433,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",

--- a/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/custom_gauge_metrics.json
+++ b/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/custom_gauge_metrics.json
@@ -24,7 +24,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "Status: ${metric__labels__buffer_entry_status}, Access Tier: ${metric__labels__access_tier_short_name}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -58,7 +59,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "Access Tiers: ${metric__labels__access_tier_short_names}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -93,7 +95,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "Access Tier: ${metric__labels__access_tier_short_name}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -123,7 +126,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "Cohort Count",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -153,7 +157,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "Cohort Review Count",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -186,7 +191,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "Domain: ${metric__labels__gsuite_domain}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",

--- a/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/distribution_metrics.json
+++ b/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/distribution_metrics.json
@@ -22,7 +22,8 @@
                                 "unitOverride": "ms"
                             },
                             "plotType": "HEATMAP",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -51,7 +52,8 @@
                                 "unitOverride": "ms"
                             },
                             "plotType": "HEATMAP",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -83,7 +85,8 @@
                                 "unitOverride": "ms"
                             },
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -115,7 +118,8 @@
                                 "unitOverride": "ms"
                             },
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",

--- a/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/http_monitoring.json
+++ b/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/http_monitoring.json
@@ -22,7 +22,8 @@
                                 "unitOverride": "1"
                             },
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "300s"
+                            "minAlignmentPeriod": "300s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -54,7 +55,8 @@
                                 "unitOverride": "1"
                             },
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "300s"
+                            "minAlignmentPeriod": "300s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",

--- a/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/operations.json
+++ b/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/operations.json
@@ -22,7 +22,8 @@
                                 "unitOverride": "1"
                             },
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "300s"
+                            "minAlignmentPeriod": "300s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -54,7 +55,8 @@
                                 "unitOverride": "ms"
                             },
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -83,7 +85,8 @@
                                 "unitOverride": "ms"
                             },
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         },
                         {
                             "timeSeriesQuery": {
@@ -97,7 +100,8 @@
                                 "unitOverride": "ms"
                             },
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         },
                         {
                             "timeSeriesQuery": {
@@ -111,7 +115,8 @@
                                 "unitOverride": "ms"
                             },
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -143,7 +148,8 @@
                                 "unitOverride": "1"
                             },
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -177,7 +183,8 @@
                             },
                             "legendTemplate": "Access Tier: ${metric__labels__access_tier_short_name}, Status: ${metric__labels__active_status}",
                             "plotType": "LINE",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -209,7 +216,8 @@
                                 "unitOverride": "1"
                             },
                             "plotType": "STACKED_BAR",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -244,7 +252,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__name} ${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         },
                         {
                             "timeSeriesQuery": {
@@ -263,7 +272,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__name} ${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",
@@ -298,7 +308,8 @@
                             },
                             "plotType": "STACKED_BAR",
                             "legendTemplate": "${metric__labels__name} ${metric__labels__status}",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",

--- a/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/response_metadata.json
+++ b/modules/workbench/modules/monitoring/modules/dashboards/assets/dashboards_json/response_metadata.json
@@ -20,7 +20,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "2XX Responses",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         },
                         {
                             "timeSeriesQuery": {
@@ -35,7 +36,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "3XX Responses\n",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         },
                         {
                             "timeSeriesQuery": {
@@ -50,7 +52,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "4XX Responses",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         },
                         {
                             "timeSeriesQuery": {
@@ -65,7 +68,8 @@
                             },
                             "plotType": "LINE",
                             "legendTemplate": "5XX Responses",
-                            "minAlignmentPeriod": "60s"
+                            "minAlignmentPeriod": "60s",
+                            "targetAxis": "Y1"
                         }
                     ],
                     "timeshiftDuration": "0s",


### PR DESCRIPTION
Updates our config to match current infrastructure. No changes will need to be applied.

`terraform plan` currently outputs many changes of the format:
`- targetAxis         = "Y1" -> null`
`- etag        = "..." -> null`
and
`- name        = "..." -> null`

The `targetAxis` field is automatically set by GCP if not set manually by us. When the change to "null" is applied, the field remains equal to "Y1".

Because the field is part of a json parameter, we are unable to ignore this specific parameter.

Setting this field to "Y1" removes the diff without changing existing infrastructure. Because we have been using this default for some time, I don't think this is an error in configuration.

The changes to fields "name" and "etag" are also removed with this change. They are automatically ignored by Terraform, but still show up in `plan` and `apply` diffs when there is another change present.