### PR TITLE
[RW-10520][risk=no] Shifted identity changes to end of file

### DIFF
--- a/modules/workbench/modules/reporting/assets/schemas/user.json
+++ b/modules/workbench/modules/reporting/assets/schemas/user.json
@@ -103,13 +103,13 @@
   {
     "name": "ras_login_gov_bypass_time",
     "type": "TIMESTAMP",
-    "description": "Time an administrator bypassed the RAS Login.gov requirement for this user.",
+    "description": "[DELETED] Time an administrator bypassed the RAS Login.gov requirement for this user.",
     "mode": "NULLABLE"
   },
   {
     "name": "ras_login_gov_completion_time",
     "type": "TIMESTAMP",
-    "description": "Time user completed the RAS Login.gov account link.",
+    "description": "[DELETED] Was: Time user completed the RAS Login.gov account link.",
     "mode": "NULLABLE"
   },
   {
@@ -312,6 +312,24 @@
     "name": "access_tier_short_names",
     "type": "STRING",
     "description": "List of access tiers available to the user, comma-delimited if multiple",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "identity_bypass_time",
+    "type": "TIMESTAMP",
+    "description": "Time an administrator bypassed the identity requirement for this user.",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "identity_completion_time",
+    "type": "TIMESTAMP",
+    "description": "Time user completed the identity requirement.",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "identity_verification_system",
+    "type": "STRING",
+    "description": "The system that the user used to complete identity verification.",
     "mode": "NULLABLE"
   }
 ]


### PR DESCRIPTION
Related change: https://github.com/all-of-us/workbench/pull/7843

Putting Identity fields in the middle of the json appears to make terraform think that there is a much larger change than there was. Shifting changes to end of file.