### PR TITLE
[no ticket][risk=no] Allow destroy and fix a typo 

### DIFF
--- a/modules/workbench/modules/reporting/main.tf
+++ b/modules/workbench/modules/reporting/main.tf
@@ -29,6 +29,7 @@ locals {
     #   to refer to other values in the same object when defining it.
     table_id    = replace(basename(full_path), local.TABLE_SCHEMA_SUFFIX, "")
     range_partitioning = null
+    deletion_protection = false
   }]
 
   # Merge calculated inputs with the ones we use every time.

--- a/modules/workbench/outputs.tf
+++ b/modules/workbench/outputs.tf
@@ -12,6 +12,6 @@ output "table_names" {
 
 output "docker_repo_name" {
   description = "Remote docker GAR repo name"
-  value       = module.repository.docker_repo_name
+  value       = module.artifact_registry.docker_repo_name
 }
 


### PR DESCRIPTION
Destry protection is a new feature added in BQ. I think we would need that because sometime we need to recreate a table with new BQ provider updates. Tested that, seems to be working fine in test and local