### PR TITLE
[noTicket][risk=no]Rename cron job check free tier billing usage

### DIFF
--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_free_tier_billing_usage.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_free_tier_billing_usage.json
@@ -3,7 +3,7 @@
   "conditions": [
     {
       "conditionAbsent": {
-        "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"checkFreeTierBillingUsageCloudTask\" metric.label.\"status\"=\"204\"",
+        "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"checkFreeTierBillingUsage\" metric.label.\"status\"=\"204\"",
         "duration": "7200s",
         "trigger": {
           "percent": 100
@@ -16,7 +16,7 @@
           }
         ]
       },
-      "displayName": "checkFreeTierBillingUsageCloudTask Cron Signal Absent",
+      "displayName": "checkFreeTierBillingUsage Cron Signal Absent",
       "name": "projects/all-of-us-rw-prod/alertPolicies/10595350486947347942/conditions/10595350486947344889"
     }
   ],


### PR DESCRIPTION
Follow up for PR https://github.com/all-of-us/workbench/pull/8569
We are updating the name of cron job checkFreeTierBillingUsageCloudTask to avoid confusion and follow the naming pattern, 

This will be pushed once the original PR is released to PROD