### PR TITLE
[risk=moderate][RW-11850] Add Workload Identity Pool and OIDC Provider for CircleCI

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,9 @@ One recommended way can be:
     * Lists alert policies: `gcloud alpha monitoring policies list --project all-of-us-rw-prod --format json`
 3. Create/Replace the new json file.
 4. Apply this change to other envs.
+
+### Artifact Registry
+TODO
+
+### Workload Identity
+TODO

--- a/README.md
+++ b/README.md
@@ -58,7 +58,13 @@ One recommended way can be:
 4. Apply this change to other envs.
 
 ### Artifact Registry
-TODO
+Google Artifact Registry allows us to provide Docker Hub access to members of the Registered and Controlled Tiers.
 
 ### Workload Identity
-TODO
+Workload Identity Federation allows us to grant access to our Service Accounts to external services without using keys
+or stored credentials.
+
+These steps allow CircleCI to impersonate an SA for use in deployment:
+1. Create a Workflow Identity Pool
+2. Create a Workflow Identity Pool Provider
+3. Grant access to the deployment Service Account to the Workflow Identity Pool

--- a/TERRAFORM_QUICKSTART.md
+++ b/TERRAFORM_QUICKSTART.md
@@ -13,7 +13,7 @@ command name repeatedly below.
 
 ## Installation
 For the work so far, I've used the [Terraform CLI](https://www.terraform.io/docs/cli-index.html), which has the  advantage of not costing
-money or requiring an email registration. On the mac, `brew inistall terraform` is pretty much all it takes. 
+money or requiring an email registration. On the mac, `brew install terraform` is pretty much all it takes. 
 
 Terraform works by keeping state  on the local filesystem for evaluating diffs and staging changes. Primary files for users to author
 and check in to source control are:
@@ -66,7 +66,7 @@ by installing the FileWitchers plugin and adding a Terraform Format action. Runs
 It's handy to have a human-readable label called `managedByTerraform` and set it to `true` for all TF artifacts.
 It's possible to set up default labels and things for this.
 ### Local Variables
-Using a `locals` bock allows you to assign values (computed once) to variables to be used elsewhere. This
+Using a `locals` block allows you to assign values (computed once) to variables to be used elsewhere. This
 is especially useful for nested map lookups: 
 ```hcl-terraform
 locals {
@@ -132,7 +132,7 @@ the most part going to one organization for help with the other's platform will 
 at best. Good luck differentiating them on your resume.
 
 ### Mis-configuring a tfstate file
-The file really shouldn't be checked into source contol, because
+The file really shouldn't be checked into source control, because
 it's not safe to have multiple developers working with it. It's too easy to getinito an inconsistent view of the world.
 
 However, that doesn't mean it's safe to lost track of the tfstate JSON file altogether.

--- a/modules/workbench/main.tf
+++ b/modules/workbench/main.tf
@@ -29,3 +29,12 @@ module "artifact_registry" {
   registered_tier_group_name = var.registered_tier_group_name
   controlled_tier_group_name = var.controlled_tier_group_name
 }
+
+# Workload Identity
+module "workload_identity" {
+  source = "./modules/workload_identity"
+  project_id = var.project_id
+  aou_env = var.aou_env
+  circleci_org_id = var.circleci_org_id
+  circleci_service_account_email = var.circleci_service_account_email
+}

--- a/modules/workbench/modules/workload_identity/main.tf
+++ b/modules/workbench/modules/workload_identity/main.tf
@@ -2,15 +2,15 @@
 
 resource "google_iam_workload_identity_pool" "circleci" {
   project = var.project_id
-  workload_identity_pool_id = "circleci-oidc-pool-${var.aou_env}"
+  workload_identity_pool_id = "circleci-wip-${var.aou_env}"
   display_name              = "CircleCI WIP - ${var.aou_env}"
-  description               = "Identity pool for CircleCI OIDC authentication - ${var.aou_env}"
+  description               = "Identity pool for CircleCI - ${var.aou_env}"
 }
 
 resource "google_iam_workload_identity_pool_provider" "circleci" {
   workload_identity_pool_id          = google_iam_workload_identity_pool.circleci.workload_identity_pool_id
   workload_identity_pool_provider_id = "circleci-oidc-prv-${var.aou_env}"
-  display_name                       = "CircleCI WIP Provider - ${var.aou_env}"
+  display_name                       = "CircleCI OIDC Provider - ${var.aou_env}"
   description                        = "Identity pool provider for CircleCI OIDC authentication - ${var.aou_env}"
   attribute_condition                = "attribute.org_id=='${var.circleci_org_id}'"
   attribute_mapping = {

--- a/modules/workbench/modules/workload_identity/main.tf
+++ b/modules/workbench/modules/workload_identity/main.tf
@@ -2,16 +2,16 @@
 
 resource "google_iam_workload_identity_pool" "circleci" {
   project = var.project_id
-  workload_identity_pool_id = "${var.aou_env}-2-oidc-pool"
-  display_name              = "${var.aou_env} OIDC Auth Pool v2"
-  description               = "Identity pool for CircleCI OIDC authentication - ${var.aou_env} v2"
+  workload_identity_pool_id = "circleci-oidc-pool-${var.aou_env}"
+  display_name              = "Circle OIDC Auth Pool for ${var.aou_env}"
+  description               = "Identity pool for CircleCI OIDC authentication - ${var.aou_env}"
 }
 
 resource "google_iam_workload_identity_pool_provider" "circleci" {
   workload_identity_pool_id          = google_iam_workload_identity_pool.circleci.workload_identity_pool_id
-  workload_identity_pool_provider_id = "${var.aou_env}-2-oidc-prv"
-  display_name                       = "${var.aou_env} OIDC Auth v2"
-  description                        = "Identity pool provider for CircleCI OIDC authentication - ${var.aou_env} v2"
+  workload_identity_pool_provider_id = "circleci-oidc-prv-${var.aou_env}"
+  display_name                       = "Circle OIDC Auth Pool Provider for ${var.aou_env}"
+  description                        = "Identity pool provider for CircleCI OIDC authentication - ${var.aou_env}"
   attribute_condition                = "attribute.org_id=='${var.circleci_org_id}'"
   attribute_mapping = {
     "attribute.org_id" = "assertion.aud",

--- a/modules/workbench/modules/workload_identity/main.tf
+++ b/modules/workbench/modules/workload_identity/main.tf
@@ -1,14 +1,14 @@
 # adapted from https://github.com/jtreutel/circleci-gcp-oidc-terraform/blob/master/main.tf
 
-resource "google_iam_workload_identity_pool" "circleci" {
+resource "google_iam_workload_identity_pool" "circleci2" {
   project = var.project_id
   workload_identity_pool_id = "${var.aou_env}-oidc-pool"
   display_name              = "${var.aou_env} OIDC Auth Pool"
   description               = "Identity pool for CircleCI OIDC authentication - ${var.aou_env}"
 }
 
-resource "google_iam_workload_identity_pool_provider" "circleci" {
-  workload_identity_pool_id          = google_iam_workload_identity_pool.circleci.workload_identity_pool_id
+resource "google_iam_workload_identity_pool_provider" "circleci2" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.circleci2.workload_identity_pool_id
   workload_identity_pool_provider_id = "${var.aou_env}-oidc-prv"
   display_name                       = "${var.aou_env} OIDC Auth"
   description                        = "Identity pool provider for CircleCI OIDC authentication - ${var.aou_env}"
@@ -36,5 +36,5 @@ data "google_service_account" "circleci_service_account" {
 resource "google_service_account_iam_member" "circleci_impersonation" {
   service_account_id = data.google_service_account.circleci_service_account.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.circleci.workload_identity_pool_id}/attribute.org_id/${var.circleci_org_id}"
+  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.circleci2.workload_identity_pool_id}/attribute.org_id/${var.circleci_org_id}"
 }

--- a/modules/workbench/modules/workload_identity/main.tf
+++ b/modules/workbench/modules/workload_identity/main.tf
@@ -1,17 +1,17 @@
 # adapted from https://github.com/jtreutel/circleci-gcp-oidc-terraform/blob/master/main.tf
 
-resource "google_iam_workload_identity_pool" "circleci2" {
+resource "google_iam_workload_identity_pool" "circleci" {
   project = var.project_id
-  workload_identity_pool_id = "${var.aou_env}-oidc-pool"
-  display_name              = "${var.aou_env} OIDC Auth Pool"
-  description               = "Identity pool for CircleCI OIDC authentication - ${var.aou_env}"
+  workload_identity_pool_id = "${var.aou_env}-2-oidc-pool"
+  display_name              = "${var.aou_env} OIDC Auth Pool v2"
+  description               = "Identity pool for CircleCI OIDC authentication - ${var.aou_env} v2"
 }
 
-resource "google_iam_workload_identity_pool_provider" "circleci2" {
-  workload_identity_pool_id          = google_iam_workload_identity_pool.circleci2.workload_identity_pool_id
-  workload_identity_pool_provider_id = "${var.aou_env}-oidc-prv"
-  display_name                       = "${var.aou_env} OIDC Auth"
-  description                        = "Identity pool provider for CircleCI OIDC authentication - ${var.aou_env}"
+resource "google_iam_workload_identity_pool_provider" "circleci" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.circleci.workload_identity_pool_id
+  workload_identity_pool_provider_id = "${var.aou_env}-2-oidc-prv"
+  display_name                       = "${var.aou_env} OIDC Auth v2"
+  description                        = "Identity pool provider for CircleCI OIDC authentication - ${var.aou_env} v2"
   attribute_condition                = "attribute.org_id=='${var.circleci_org_id}'"
   attribute_mapping = {
     "attribute.org_id" = "assertion.aud",
@@ -36,5 +36,5 @@ data "google_service_account" "circleci_service_account" {
 resource "google_service_account_iam_member" "circleci_impersonation" {
   service_account_id = data.google_service_account.circleci_service_account.name
   role               = "roles/iam.workloadIdentityUser"
-  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.circleci2.workload_identity_pool_id}/attribute.org_id/${var.circleci_org_id}"
+  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.circleci.workload_identity_pool_id}/attribute.org_id/${var.circleci_org_id}"
 }

--- a/modules/workbench/modules/workload_identity/main.tf
+++ b/modules/workbench/modules/workload_identity/main.tf
@@ -1,5 +1,8 @@
 # adapted from https://github.com/jtreutel/circleci-gcp-oidc-terraform/blob/master/main.tf
 
+# Note: these resources require the GCP role "roles/iam.workloadIdentityPoolAdmin" in the project
+# AKA "IAM Workload Identity Pool Admin"
+
 resource "google_iam_workload_identity_pool" "circleci" {
   project = var.project_id
   workload_identity_pool_id = "circleci-wip-${var.aou_env}"

--- a/modules/workbench/modules/workload_identity/main.tf
+++ b/modules/workbench/modules/workload_identity/main.tf
@@ -1,0 +1,40 @@
+# adapted from https://github.com/jtreutel/circleci-gcp-oidc-terraform/blob/master/main.tf
+
+resource "google_iam_workload_identity_pool" "circleci" {
+  project = var.project_id
+  workload_identity_pool_id = "${var.aou_env}-oidc-pool"
+  display_name              = "${var.aou_env} OIDC Auth Pool"
+  description               = "Identity pool for CircleCI OIDC authentication - ${var.aou_env}"
+}
+
+resource "google_iam_workload_identity_pool_provider" "circleci" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.circleci.workload_identity_pool_id
+  workload_identity_pool_provider_id = "${var.aou_env}-oidc-prv"
+  display_name                       = "${var.aou_env} OIDC Auth"
+  description                        = "Identity pool provider for CircleCI OIDC authentication - ${var.aou_env}"
+  attribute_condition                = "attribute.org_id=='${var.circleci_org_id}'"
+  attribute_mapping = {
+    "attribute.org_id" = "assertion.aud",
+    "google.subject"   = "assertion.sub"
+  }
+  oidc {
+    allowed_audiences = [var.circleci_org_id]
+    issuer_uri        = "https://oidc.circleci.com/org/${var.circleci_org_id}"
+  }
+}
+
+# allows retrieval of the google project number
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+# allows retrieval of the service account's full path, as its "name"
+data "google_service_account" "circleci_service_account" {
+  account_id = var.circleci_service_account_email
+}
+
+resource "google_service_account_iam_member" "circleci_impersonation" {
+  service_account_id = data.google_service_account.circleci_service_account.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/projects/${data.google_project.project.number}/locations/global/workloadIdentityPools/${google_iam_workload_identity_pool.circleci.workload_identity_pool_id}/attribute.org_id/${var.circleci_org_id}"
+}

--- a/modules/workbench/modules/workload_identity/main.tf
+++ b/modules/workbench/modules/workload_identity/main.tf
@@ -3,14 +3,14 @@
 resource "google_iam_workload_identity_pool" "circleci" {
   project = var.project_id
   workload_identity_pool_id = "circleci-oidc-pool-${var.aou_env}"
-  display_name              = "Circle OIDC Auth Pool for ${var.aou_env}"
+  display_name              = "CircleCI WIP - ${var.aou_env}"
   description               = "Identity pool for CircleCI OIDC authentication - ${var.aou_env}"
 }
 
 resource "google_iam_workload_identity_pool_provider" "circleci" {
   workload_identity_pool_id          = google_iam_workload_identity_pool.circleci.workload_identity_pool_id
   workload_identity_pool_provider_id = "circleci-oidc-prv-${var.aou_env}"
-  display_name                       = "Circle OIDC Auth Pool Provider for ${var.aou_env}"
+  display_name                       = "CircleCI WIP Provider - ${var.aou_env}"
   description                        = "Identity pool provider for CircleCI OIDC authentication - ${var.aou_env}"
   attribute_condition                = "attribute.org_id=='${var.circleci_org_id}'"
   attribute_mapping = {

--- a/modules/workbench/modules/workload_identity/outputs.tf
+++ b/modules/workbench/modules/workload_identity/outputs.tf
@@ -1,9 +1,9 @@
 output "workload_identity_pool_id" {
   description = "Workload Identity Pool ID"
-  value       = google_iam_workload_identity_pool.circleci2.id
+  value       = google_iam_workload_identity_pool.circleci.id
 }
 
 output "workload_identity_pool_provider_id" {
   description = "Workload Identity Pool Provider ID"
-  value       = google_iam_workload_identity_pool_provider.circleci2.id
+  value       = google_iam_workload_identity_pool_provider.circleci.id
 }

--- a/modules/workbench/modules/workload_identity/outputs.tf
+++ b/modules/workbench/modules/workload_identity/outputs.tf
@@ -1,9 +1,9 @@
 output "workload_identity_pool_id" {
   description = "Workload Identity Pool ID"
-  value       = google_iam_workload_identity_pool.circleci.id
+  value       = google_iam_workload_identity_pool.circleci2.id
 }
 
 output "workload_identity_pool_provider_id" {
   description = "Workload Identity Pool Provider ID"
-  value       = google_iam_workload_identity_pool_provider.circleci.id
+  value       = google_iam_workload_identity_pool_provider.circleci2.id
 }

--- a/modules/workbench/modules/workload_identity/outputs.tf
+++ b/modules/workbench/modules/workload_identity/outputs.tf
@@ -1,0 +1,9 @@
+output "workload_identity_pool_id" {
+  description = "Workload Identity Pool ID"
+  value       = google_iam_workload_identity_pool.circleci.id
+}
+
+output "workload_identity_pool_provider_id" {
+  description = "Workload Identity Pool Provider ID"
+  value       = google_iam_workload_identity_pool_provider.circleci.id
+}

--- a/modules/workbench/modules/workload_identity/variables.tf
+++ b/modules/workbench/modules/workload_identity/variables.tf
@@ -1,0 +1,19 @@
+variable project_id {
+  description = "GCP Project"
+  type        = string
+}
+
+variable aou_env {
+  description = "Short name (all lowercase) of All of Us Workbench deployed environments, e.g. local, test, staging, prod."
+  type        = string
+}
+
+variable "circleci_org_id" {
+  type        = string
+  description = "Your CircleCI org ID.  Can be found under \"Organization Settings\" in the CircleCI application."
+}
+
+variable "circleci_service_account_email" {
+  type        = string
+  description = "The email address of the service account that CircleCI will impersonate."
+}

--- a/modules/workbench/variables.tf
+++ b/modules/workbench/variables.tf
@@ -98,3 +98,17 @@ variable controlled_tier_group_name {
   description = "Google group that contains all controlled tier users"
   type        = string
 }
+
+#
+# Workload Identity
+#
+
+variable circleci_org_id {
+  type        = string
+  description = "Your CircleCI org ID.  Can be found under \"Organization Settings\" in the CircleCI application."
+}
+
+variable circleci_service_account_email {
+  type        = string
+  description = "The email address of the service account that CircleCI will impersonate."
+}


### PR DESCRIPTION
Allow CircleCI to impersonate each environment's deployment Service Account by using OIDC and Workload Identity Federation.

<img width="507" alt="WIP and Provider" src="https://github.com/all-of-us/workbench-terraform-modules/assets/2701406/8d80e4a2-69e1-4305-993a-4def2e39d24f">

Flagging as **moderate** because this is a security change.

The corresponding Devops change is https://github.com/all-of-us/workbench-devops/pull/127
The corresponding Workbench change is https://github.com/all-of-us/workbench/pull/8597