### PR TITLE
[risk=low][no ticket] Alert for all existing task queues

### DIFF
--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_access_expiration_email.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_access_expiration_email.json
@@ -10,18 +10,19 @@
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"rdrExportQueue\"",
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"accessExpirationEmailQueue\"",
         "comparison": "COMPARISON_GT",
+
         "duration": "60s",
         "thresholdValue": 0,
         "trigger": {
           "count": 1
         }
       },
-      "displayName": "Cloud Task failure: rdrExportQueue"
+      "displayName": "Cloud Task failure: accessExpirationEmailQueue"
     }
   ],
-  "displayName": "Cloud Task failure: rdrExportQueue",
+  "displayName": "Cloud Task failure: accessExpirationEmailQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_audit_project.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_audit_project.json
@@ -10,7 +10,7 @@
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"rdrExportQueue\"",
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"auditProjectQueue\"",
         "comparison": "COMPARISON_GT",
         "duration": "60s",
         "thresholdValue": 0,
@@ -18,10 +18,10 @@
           "count": 1
         }
       },
-      "displayName": "Cloud Task failure: rdrExportQueue"
+      "displayName": "Cloud Task failure: auditProjectQueue"
     }
   ],
-  "displayName": "Cloud Task failure: rdrExportQueue",
+  "displayName": "Cloud Task failure: auditProjectQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_audit_project.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_audit_project.json
@@ -13,7 +13,7 @@
         "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"auditProjectQueue\"",
         "comparison": "COMPARISON_GT",
         "duration": "60s",
-        "thresholdValue": 0,
+        "thresholdValue": 0.1,
         "trigger": {
           "count": 1
         }

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_check_initial_credits_usage_for_ids.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_check_initial_credits_usage_for_ids.json
@@ -10,18 +10,19 @@
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"rdrExportQueue\"",
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"checkCreditsExpirationForUserIDsQueue\"",
         "comparison": "COMPARISON_GT",
+
         "duration": "60s",
         "thresholdValue": 0,
         "trigger": {
           "count": 1
         }
       },
-      "displayName": "Cloud Task failure: rdrExportQueue"
+      "displayName": "Cloud Task failure: checkCreditsExpirationForUserIDsQueue"
     }
   ],
-  "displayName": "Cloud Task failure: rdrExportQueue",
+  "displayName": "Cloud Task failure: checkCreditsExpirationForUserIDsQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_check_persistent_disks.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_check_persistent_disks.json
@@ -1,0 +1,34 @@
+{
+  "combiner": "OR",
+  "conditions": [
+    {
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "60s",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"checkPersistentDiskQueue\"",
+        "comparison": "COMPARISON_GT",
+
+        "duration": "60s",
+        "thresholdValue": 0,
+        "trigger": {
+          "count": 1
+        }
+      },
+      "displayName": "Cloud Task failure: checkPersistentDiskQueue"
+    }
+  ],
+  "displayName": "Cloud Task failure: checkPersistentDiskQueue",
+  "documentation": {
+    "content": "Playbook: https://broad.io/aou-playbook",
+    "mimeType": "text/markdown"
+  },
+  "enabled": true,
+  "notificationChannels": [
+    "projects/${project_id}/notificationChannels/${notification_channel_id}"
+  ]
+}

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_create_workspace.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_create_workspace.json
@@ -10,18 +10,19 @@
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"rdrExportQueue\"",
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"createWorkspaceQueue\"",
         "comparison": "COMPARISON_GT",
+
         "duration": "60s",
         "thresholdValue": 0,
         "trigger": {
           "count": 1
         }
       },
-      "displayName": "Cloud Task failure: rdrExportQueue"
+      "displayName": "Cloud Task failure: createWorkspaceQueue"
     }
   ],
-  "displayName": "Cloud Task failure: rdrExportQueue",
+  "displayName": "Cloud Task failure: createWorkspaceQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_delete_test_user_rawls_workspaces.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_delete_test_user_rawls_workspaces.json
@@ -10,18 +10,19 @@
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"rdrExportQueue\"",
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"deleteTestUserRawlsWorkspacesQueue\"",
         "comparison": "COMPARISON_GT",
+
         "duration": "60s",
         "thresholdValue": 0,
         "trigger": {
           "count": 1
         }
       },
-      "displayName": "Cloud Task failure: rdrExportQueue"
+      "displayName": "Cloud Task failure: deleteTestUserRawlsWorkspacesQueue"
     }
   ],
-  "displayName": "Cloud Task failure: rdrExportQueue",
+  "displayName": "Cloud Task failure: deleteTestUserRawlsWorkspacesQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_delete_test_user_workspaces.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_delete_test_user_workspaces.json
@@ -10,18 +10,19 @@
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"rdrExportQueue\"",
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"deleteTestUserWorkspacesQueue\"",
         "comparison": "COMPARISON_GT",
+
         "duration": "60s",
         "thresholdValue": 0,
         "trigger": {
           "count": 1
         }
       },
-      "displayName": "Cloud Task failure: rdrExportQueue"
+      "displayName": "Cloud Task failure: deleteTestUserWorkspacesQueue"
     }
   ],
-  "displayName": "Cloud Task failure: rdrExportQueue",
+  "displayName": "Cloud Task failure: deleteTestUserWorkspacesQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_delete_unshared_workspace_environments.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_delete_unshared_workspace_environments.json
@@ -10,18 +10,19 @@
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"rdrExportQueue\"",
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"deleteUnsharedWorkspaceEnvironmentsQueue\"",
         "comparison": "COMPARISON_GT",
+
         "duration": "60s",
         "thresholdValue": 0,
         "trigger": {
           "count": 1
         }
       },
-      "displayName": "Cloud Task failure: rdrExportQueue"
+      "displayName": "Cloud Task failure: deleteUnsharedWorkspaceEnvironmentsQueue"
     }
   ],
-  "displayName": "Cloud Task failure: rdrExportQueue",
+  "displayName": "Cloud Task failure: deleteUnsharedWorkspaceEnvironmentsQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_duplicate_workspace.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_duplicate_workspace.json
@@ -10,18 +10,19 @@
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"rdrExportQueue\"",
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"duplicateWorkspaceQueue\"",
         "comparison": "COMPARISON_GT",
+
         "duration": "60s",
         "thresholdValue": 0,
         "trigger": {
           "count": 1
         }
       },
-      "displayName": "Cloud Task failure: rdrExportQueue"
+      "displayName": "Cloud Task failure: duplicateWorkspaceQueue"
     }
   ],
-  "displayName": "Cloud Task failure: rdrExportQueue",
+  "displayName": "Cloud Task failure: duplicateWorkspaceQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_initial_credits_exhaustion.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_initial_credits_exhaustion.json
@@ -10,7 +10,7 @@
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"freeTierBillingQueue\"",
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"initialCreditsExhaustionQueue\"",
         "comparison": "COMPARISON_GT",
 
         "duration": "60s",
@@ -19,10 +19,10 @@
           "count": 1
         }
       },
-      "displayName": "freeTierBillingQueue task failure"
+      "displayName": "Cloud Task failure: initialCreditsExhaustionQueue"
     }
   ],
-  "displayName": "Cloud Task failure: freeTierBillingQueue",
+  "displayName": "Cloud Task failure: initialCreditsExhaustionQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_initial_credits_usage.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_initial_credits_usage.json
@@ -10,18 +10,19 @@
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"rdrExportQueue\"",
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"initialCreditsUsageQueue\"",
         "comparison": "COMPARISON_GT",
+
         "duration": "60s",
         "thresholdValue": 0,
         "trigger": {
           "count": 1
         }
       },
-      "displayName": "Cloud Task failure: rdrExportQueue"
+      "displayName": "Cloud Task failure: initialCreditsUsageQueue"
     }
   ],
-  "displayName": "Cloud Task failure: rdrExportQueue",
+  "displayName": "Cloud Task failure: initialCreditsUsageQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_process_egress_event.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_process_egress_event.json
@@ -19,7 +19,7 @@
           "count": 1
         }
       },
-      "displayName": "egressEventQueue task failure"
+      "displayName": "Cloud Task failure: egressEventQueue"
     }
   ],
   "displayName": "Cloud Task failure: egressEventQueue",

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_synchronize_user_access.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_synchronize_user_access.json
@@ -19,10 +19,10 @@
           "count": 1
         }
       },
-      "displayName": "synchronizeAccessQueue task failure"
+      "displayName": "Cloud Task failure: synchronizeAccessQueue"
     }
   ],
-  "displayName": "Cloud Task failure: synchronizeUserAccess",
+  "displayName": "Cloud Task failure: synchronizeAccessQueue",
   "documentation": {
     "content": "Playbook: https://broad.io/aou-playbook",
     "mimeType": "text/markdown"


### PR DESCRIPTION
Update our Task Queue alerts (see https://github.com/all-of-us/workbench/wiki/Monitoring,-Alerts,-and-Dashboards ) to include all current queues. We've missed many of them.  Prod env alerts go to Slack #workbench-alerts and all other environment alerts go to #workbench-alert-test.  (see https://github.com/all-of-us/workbench-devops/blob/main/terraform-live/modules/prod/main.tf#L64)

A similar cron update to follow. 