### PR TITLE
[risk=low][RW-14558] Set all duration+alignment windows to (23h30m + 1 hr)

### DIFF
--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_audit_project_access.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_audit_project_access.json
@@ -4,13 +4,13 @@
     {
       "conditionAbsent": {
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"bulkAuditProjectAccess\" metric.label.\"status\"=\"204\"",
-        "duration": "89940s",
+        "duration": "84600s",
         "trigger": {
           "percent": 100
         },
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "perSeriesAligner": "ALIGN_RATE",
             "crossSeriesReducer": "REDUCE_SUM"
           }

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_check_initial_credits_expiration.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_check_initial_credits_expiration.json
@@ -4,13 +4,13 @@
     {
       "conditionAbsent": {
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"checkInitialCreditsExpiration\" metric.label.\"status\"=\"204\"",
-        "duration": "89940s",
+        "duration": "84600s",
         "trigger": {
           "percent": 100
         },
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "perSeriesAligner": "ALIGN_RATE",
             "crossSeriesReducer": "REDUCE_SUM"
           }

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_check_initial_credits_usage.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_check_initial_credits_usage.json
@@ -4,13 +4,13 @@
     {
       "conditionAbsent": {
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"checkInitialCreditsUsage\" metric.label.\"status\"=\"204\"",
-        "duration": "89940s",
+        "duration": "84600s",
         "trigger": {
           "percent": 100
         },
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "perSeriesAligner": "ALIGN_RATE",
             "crossSeriesReducer": "REDUCE_SUM"
           }

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_check_object_name_size.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_check_object_name_size.json
@@ -4,13 +4,13 @@
     {
       "conditionAbsent": {
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"checkObjectNameSize\" metric.label.\"status\"=\"204\"",
-        "duration": "89940s",
+        "duration": "84600s",
         "trigger": {
           "percent": 100
         },
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "perSeriesAligner": "ALIGN_RATE",
             "crossSeriesReducer": "REDUCE_SUM"
           }

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_check_persistent_disks.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_check_persistent_disks.json
@@ -4,13 +4,13 @@
     {
       "conditionAbsent": {
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"checkPersistentDisks\" metric.label.\"status\"=\"204\"",
-        "duration": "89940s",
+        "duration": "84600s",
         "trigger": {
           "percent": 100
         },
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "perSeriesAligner": "ALIGN_RATE",
             "crossSeriesReducer": "REDUCE_SUM"
           }

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_delete_test_user_rawls_workspaces.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_delete_test_user_rawls_workspaces.json
@@ -5,12 +5,12 @@
       "conditionAbsent": {
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "crossSeriesReducer": "REDUCE_SUM",
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "duration": "89940s",
+        "duration": "84600s",
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"deleteTestUserWorkspacesOrphanedInRawls\" metric.label.\"status\"=\"204\"",
         "trigger": {
           "percent": 100

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_delete_test_user_workspaces.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_delete_test_user_workspaces.json
@@ -5,12 +5,12 @@
       "conditionAbsent": {
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "crossSeriesReducer": "REDUCE_SUM",
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "duration": "89940s",
+        "duration": "84600s",
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"deleteTestUserWorkspaces\" metric.label.\"status\"=\"204\"",
         "trigger": {
           "percent": 100

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_delete_unshared_workspace_environments.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_delete_unshared_workspace_environments.json
@@ -5,12 +5,12 @@
       "conditionAbsent": {
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "crossSeriesReducer": "REDUCE_SUM",
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "duration": "89940s",
+        "duration": "84600s",
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"deleteUnsharedWorkspaceEnvironments\" metric.label.\"status\"=\"204\"",
         "trigger": {
           "percent": 100

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_email_new_user_survey.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_email_new_user_survey.json
@@ -5,12 +5,12 @@
       "conditionAbsent": {
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "crossSeriesReducer": "REDUCE_SUM",
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "duration": "89940s",
+        "duration": "84600s",
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"emailNewUserSatisfactionSurveyLinks\" metric.label.\"status\"=\"204\"",
         "trigger": {
           "percent": 100

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_ensure_tos_compliance.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_ensure_tos_compliance.json
@@ -5,12 +5,12 @@
       "conditionAbsent": {
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "crossSeriesReducer": "REDUCE_SUM",
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "duration": "89940s",
+        "duration": "84600s",
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"ensureTestUserTosCompliance\" metric.label.\"status\"=\"204\"",
         "trigger": {
           "percent": 100

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_export_to_rdr.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_export_to_rdr.json
@@ -5,12 +5,12 @@
       "conditionAbsent": {
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "crossSeriesReducer": "REDUCE_SUM",
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "duration": "89940s",
+        "duration": "84600s",
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"exportToRdr\" metric.label.\"status\"=\"204\"",
         "trigger": {
           "percent": 100

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_send_access_expiration_emails.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_send_access_expiration_emails.json
@@ -5,12 +5,12 @@
       "conditionAbsent": {
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "crossSeriesReducer": "REDUCE_SUM",
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "duration": "89940s",
+        "duration": "84600s",
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"status\"=\"204\" metric.label.\"name\"=\"sendAccessExpirationEmails\"",
         "trigger": {
           "percent": 100

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_synchronize_user_access.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_synchronize_user_access.json
@@ -5,12 +5,12 @@
       "conditionAbsent": {
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "crossSeriesReducer": "REDUCE_SUM",
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "duration": "89940s",
+        "duration": "84600s",
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"name\"=\"synchronizeUserAccess\" metric.label.\"status\"=\"204\"",
         "trigger": {
           "percent": 100

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_upload_reporting_snapshot.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/cron_failure_upload_reporting_snapshot.json
@@ -5,12 +5,12 @@
       "conditionAbsent": {
         "aggregations": [
           {
-            "alignmentPeriod": "60s",
+            "alignmentPeriod": "3600s",
             "crossSeriesReducer": "REDUCE_SUM",
             "perSeriesAligner": "ALIGN_RATE"
           }
         ],
-        "duration": "89940s",
+        "duration": "84600s",
         "filter": "metric.type=\"logging.googleapis.com/user/cron_job_completion\" resource.type=\"gae_app\" metric.label.\"status\"=\"204\" metric.label.\"name\"=\"uploadReportingSnapshot\"",
         "trigger": {
           "percent": 100


### PR DESCRIPTION
There is some configuration difference between Test/Local and Staging/Stable (I haven't tried Prod/Preprod) which made it impossible to apply the Test alerting rules to Staging/Stable: cannot set **duration** above 23h30m.  Oddly, this appears to be a GCP-wide restriction, and I can't figure out why it's allowed in Test!

For example, I see this error on Staging when I try to apply workbench-terraform-modules v0.4.6, but **not** in Test.
```
╷
│ Error: Error updating AlertPolicy "projects/all-of-us-rw-staging/alertPolicies/3191228135367459128": googleapi: Error 400: Field alert_policy.conditions[0].condition_absent.duration had an invalid value of "24h59m": Durations longer than 23h30m are not supported.
│
│   with module.workbench.module.monitoring.module.alert_policies.google_monitoring_alert_policy.policy["cron_failure_upload_reporting_snapshot"],
│   on .terraform/modules/workbench/modules/workbench/modules/monitoring/modules/alert_policies/main.tf line 20, in resource "google_monitoring_alert_policy" "policy":
│   20: resource "google_monitoring_alert_policy" "policy" {
```

The reason we want a duration of ~ 25 hours is to avoid false positives for daily runs: we don't want to trigger if we see a completion signal at 11:01 one day but 11:03 the next.  But looking further, it's not only the duration which matters.  It's the duration plus an **alignmentPeriod**.  We can satisfy the rule and our requirement in all environments (confirmed) by setting a duration of 23h30m (84600 seconds) and an alignmentPeriod of 1h (3600 s) for a total of 24h30m.

https://cloud.google.com/monitoring/alerts/concepts-indepth

Crons which run more frequently than daily are not affected by this, so they are not updated here.