### PR TITLE
[RW-14808][risk=no] Add workspace_user table to WRD

### DIFF
--- a/modules/workbench/modules/reporting/assets/schemas/workspace_user.json
+++ b/modules/workbench/modules/reporting/assets/schemas/workspace_user.json
@@ -1,0 +1,25 @@
+[
+  {
+    "description": "Time snapshot was taken, in Epoch milliseconds. Same across all rows and all tables in the snapshot, and uniquely defines a particular snapshot.",
+    "name": "snapshot_timestamp",
+    "type": "INTEGER"
+  },
+  {
+    "name": "workspace_id",
+    "type": "INTEGER",
+    "description": "Primary key of the workspace table in the Workbench application database. Join with workspace_id in workspace table to get more workspace information.",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "user_id",
+    "type": "INTEGER",
+    "description": "User ID of user. Join with user_id in user table to get more user information.",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "role",
+    "type": "STRING",
+    "description": "The user's role on the workspace.",
+    "mode": "NULLABLE"
+  }
+]


### PR DESCRIPTION
Ticket: [RW-14808](https://precisionmedicineinitiative.atlassian.net/browse/RW-14808)
* Upload workspace user information to WRD. See https://github.com/all-of-us/workbench/pull/9383
* Successfully applied these changes to local WRD and confirmed that they work with the changes linked in the above PR. Plan attached below

```
Terraform will perform the following actions:

  # module.workbench.module.monitoring.module.metric_descriptors.google_logging_metric.logging_metric["cron_job_completion"] will be updated in-place
  ~ resource "google_logging_metric" "logging_metric" {
      ~ filter           = <<-EOT
            resource.type="gae_app"
          - logName="projects/all-of-us-workbench-test/logs/appengine.googleapis.com%2Frequest_log"
          + logName="projects/aou-rw-tf-sandbox-dev/logs/appengine.googleapis.com%2Frequest_log"
            protoPayload.resource:"/v1/cron/"
        EOT
        id               = "cron_job_completion"
        name             = "cron_job_completion"
        # (4 unchanged attributes hidden)

        # (1 unchanged block hidden)
    }

  # module.workbench.module.reporting.module.main.google_bigquery_table.main["workspace_user"] will be created
  + resource "google_bigquery_table" "main" {
      + clustering                   = []
      + creation_time                = (known after apply)
      + dataset_id                   = "reporting_local"
      + deletion_protection          = true
      + effective_labels             = {
          + "goog-terraform-provisioned" = "true"
          + "terraform_managed"          = "true"
        }
      + etag                         = (known after apply)
      + expiration_time              = 0
      + friendly_name                = "workspace_user"
      + generated_schema_columns     = (known after apply)
      + id                           = (known after apply)
      + ignore_auto_generated_schema = false
      + labels                       = {
          + "terraform_managed" = "true"
        }
      + last_modified_time           = (known after apply)
      + location                     = (known after apply)
      + max_staleness                = (known after apply)
      + num_bytes                    = (known after apply)
      + num_long_term_bytes          = (known after apply)
      + num_rows                     = (known after apply)
      + project                      = "all-of-us-workbench-test"
      + schema                       = jsonencode(
            [
              + {
                  + description = "Time snapshot was taken, in Epoch milliseconds. Same across all rows and all tables in the snapshot, and uniquely defines a particular snapshot."
                  + name        = "snapshot_timestamp"
                  + type        = "INTEGER"
                },
              + {
                  + description = "Primary key of the workspace table in the Workbench application database. Join with workspace_id in workspace table to get more workspace information."
                  + mode        = "NULLABLE"
                  + name        = "workspace_id"
                  + type        = "INTEGER"
                },
              + {
                  + description = "User ID of user. Join with user_id in user table to get more user information."
                  + mode        = "NULLABLE"
                  + name        = "user_id"
                  + type        = "INTEGER"
                },
              + {
                  + description = "The user's role on the workspace."
                  + mode        = "NULLABLE"
                  + name        = "role"
                  + type        = "STRING"
                },
            ]
        )
      + self_link                    = (known after apply)
      + table_id                     = "workspace_user"
      + terraform_labels             = {
          + "goog-terraform-provisioned" = "true"
          + "terraform_managed"          = "true"
        }
      + type                         = (known after apply)
    }

  # module.workbench.module.reporting.module.main.google_bigquery_table.view["live_workspace_user"] will be created
  + resource "google_bigquery_table" "view" {
      + creation_time                = (known after apply)
      + dataset_id                   = "reporting_local"
      + deletion_protection          = false
      + effective_labels             = {
          + "goog-terraform-provisioned" = "true"
          + "terraform_managed"          = "true"
        }
      + etag                         = (known after apply)
      + expiration_time              = (known after apply)
      + friendly_name                = "live_workspace_user"
      + generated_schema_columns     = (known after apply)
      + id                           = (known after apply)
      + ignore_auto_generated_schema = false
      + labels                       = {
          + "terraform_managed" = "true"
        }
      + last_modified_time           = (known after apply)
      + location                     = (known after apply)
      + max_staleness                = (known after apply)
      + num_bytes                    = (known after apply)
      + num_long_term_bytes          = (known after apply)
      + num_rows                     = (known after apply)
      + project                      = "all-of-us-workbench-test"
      + schema                       = (known after apply)
      + self_link                    = (known after apply)
      + table_id                     = "live_workspace_user"
      + terraform_labels             = {
          + "goog-terraform-provisioned" = "true"
          + "terraform_managed"          = "true"
        }
      + type                         = (known after apply)

      + view {
          + query          = <<-EOT
                -- All workspace_user rows from the most recent snapshot
                SELECT
                    t.*
                FROM
                    `all-of-us-workbench-test`.reporting_local.workspace_user t
                WHERE
                        t.snapshot_timestamp = (
                        SELECT
                            MAX(vs.snapshot_timestamp)
                        FROM
                            `all-of-us-workbench-test`.reporting_local.verified_snapshot vs);
            EOT
          + use_legacy_sql = false
        }
    }

Plan: 2 to add, 1 to change, 0 to destroy.
```

[RW-14808]: https://precisionmedicineinitiative.atlassian.net/browse/RW-14808?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ