### PR TITLE
[RW-16391][risk=no] Add alerts for WRD upload failures

### DIFF
--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/logging_last_reporting_snapshot_failure.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/logging_last_reporting_snapshot_failure.json
@@ -11,9 +11,9 @@
           }
         ],
         "comparison":  "COMPARISON_GT",
-        "duration": "180s",
+        "duration": "0s",
         "filter": "metric.type=\"logging.googleapis.com/user/reporting_upload_failure\" resource.type=\"gae_app\"",
-        "thresholdValue": 1,
+        "thresholdValue": 0.5,
         "trigger": {
           "count": 1
         }

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/logging_last_reporting_snapshot_failure.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/logging_last_reporting_snapshot_failure.json
@@ -1,0 +1,33 @@
+{
+  "combiner": "OR",
+  "conditions": [
+    {
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "60s",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "comparison":  "COMPARISON_GT",
+        "duration": "180s",
+        "filter": "metric.type=\"logging.googleapis.com/user/reporting_upload_failure\" resource.type=\"gae_app\"",
+        "thresholdValue": 1,
+        "trigger": {
+          "count": 1
+        }
+      },
+      "displayName": "Upload Reporting Snapshot Failure"
+    }
+  ],
+  "displayName": "Upload Reporting Snapshot Failure",
+  "documentation": {
+    "content": "This job monitors for failed reporting snapshot uploads\n",
+    "mimeType": "text/markdown"
+  },
+  "enabled": true,
+  "notificationChannels": [
+    "projects/${project_id}/notificationChannels/${notification_channel_id}"
+  ]
+}

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/logging_last_reporting_snapshot_failure.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/logging_last_reporting_snapshot_failure.json
@@ -23,7 +23,7 @@
   ],
   "displayName": "Upload Reporting Snapshot Failure",
   "documentation": {
-    "content": "This job monitors for failed reporting snapshot uploads\n",
+    "content": "This alert will fire if a Workbench Reporting Dataset (WRD) upload job has failed. The alert will auto-resolve, but it still requires manual investigation.\n",
     "mimeType": "text/markdown"
   },
   "enabled": true,

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/logging_last_reporting_snapshot_failure.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/logging_last_reporting_snapshot_failure.json
@@ -7,7 +7,7 @@
           {
             "alignmentPeriod": "60s",
             "crossSeriesReducer": "REDUCE_SUM",
-            "perSeriesAligner": "ALIGN_RATE"
+            "perSeriesAligner": "ALIGN_SUM"
           }
         ],
         "comparison":  "COMPARISON_GT",

--- a/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_reporting_upload.json
+++ b/modules/workbench/modules/monitoring/modules/alert_policies/assets/alert_policies/task_failure_reporting_upload.json
@@ -1,0 +1,33 @@
+{
+  "combiner": "OR",
+  "conditions": [
+    {
+      "conditionThreshold": {
+        "aggregations": [
+          {
+            "alignmentPeriod": "60s",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "perSeriesAligner": "ALIGN_RATE"
+          }
+        ],
+        "filter": "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"reportingUploadQueue\"",
+        "comparison": "COMPARISON_GT",
+        "duration": "60s",
+        "thresholdValue": 0,
+        "trigger": {
+          "count": 1
+        }
+      },
+      "displayName": "Cloud Task failure: reportingUploadQueue"
+    }
+  ],
+  "displayName": "Cloud Task failure: reportingUploadQueue",
+  "documentation": {
+    "content": "Playbook: https://broad.io/aou-playbook",
+    "mimeType": "text/markdown"
+  },
+  "enabled": true,
+  "notificationChannels": [
+    "projects/${project_id}/notificationChannels/${notification_channel_id}"
+  ]
+}

--- a/modules/workbench/modules/monitoring/modules/metric_descriptors/assets/logging_metric_descriptors/reporting_upload_failure.json
+++ b/modules/workbench/modules/monitoring/modules/metric_descriptors/assets/logging_metric_descriptors/reporting_upload_failure.json
@@ -1,7 +1,7 @@
 {
   "name": "reporting_upload_failure",
   "description": "Latest reporting snapshot failures",
-  "filter": "resource.type=\"gae_app\"\nlogName=\"projects/${project_id}/logs/%2Fvar%2Flog%2Fapp\"\ntextPayload=~\"Reporting Upload Failure:.*snapshotTimestamp=(\\\\d+)\"",
+  "filter": "resource.type=\"gae_app\"\nlogName=\"projects/${project_id}/logs/%2Fvar%2Flog%2Fapp\"\ntextPayload=~\"Reporting Upload Failure:.*[snapshotTimestamp=(\\\\d+)]\"",
   "metricDescriptor": {
     "name": "projects/${project_id}/metricDescriptors/logging.googleapis.com/user/reporting_upload_failure",
     "labels": [
@@ -23,6 +23,6 @@
   },
   "labelExtractors": {
     "insertId": "EXTRACT(insertId)",
-    "snapshot_timestamp": "REGEXP_EXTRACT(textPayload, \"Reporting Upload Failure:.*snapshotTimestamp=(\\\\d+)\"))"
+    "snapshot_timestamp": "REGEXP_EXTRACT(textPayload, \"Reporting Upload Failure:.*[snapshotTimestamp=(\\\\d+)]\")"
   }
 }

--- a/modules/workbench/modules/monitoring/modules/metric_descriptors/assets/logging_metric_descriptors/reporting_upload_failure.json
+++ b/modules/workbench/modules/monitoring/modules/metric_descriptors/assets/logging_metric_descriptors/reporting_upload_failure.json
@@ -1,0 +1,28 @@
+{
+  "name": "reporting_upload_failure",
+  "description": "Latest reporting snapshot failures",
+  "filter": "resource.type=\"gae_app\"\nlogName=\"projects/${project_id}/logs/%2Fvar%2Flog%2Fapp\"\ntextPayload=~\"Reporting Upload Failure:.*snapshotTimestamp=(\\\\d+)\"",
+  "metricDescriptor": {
+    "name": "projects/${project_id}/metricDescriptors/logging.googleapis.com/user/reporting_upload_failure",
+    "labels": [
+      {
+        "key": "insertId",
+        "description": "Insert ID. Useful for finding the log entry later"
+      },
+      {
+        "key": "snapshot_timestamp",
+        "valueType": "INT64",
+        "description": "Epoch timestamp of the failed reporting snapshot"
+      }
+    ],
+    "metricKind": "DELTA",
+    "valueType": "INT64",
+    "unit": "1",
+    "description": "Reporting snapshot failures",
+    "type": "logging.googleapis.com/user/reporting_upload_failure"
+  },
+  "labelExtractors": {
+    "insertId": "EXTRACT(insertId)",
+    "snapshot_timestamp": "REGEXP_EXTRACT(textPayload, \"Reporting Upload Failure:.*snapshotTimestamp=(\\\\d+)\"))"
+  }
+}

--- a/modules/workbench/modules/monitoring/modules/metric_descriptors/assets/logging_metric_descriptors/reporting_upload_failure.json
+++ b/modules/workbench/modules/monitoring/modules/metric_descriptors/assets/logging_metric_descriptors/reporting_upload_failure.json
@@ -23,6 +23,6 @@
   },
   "labelExtractors": {
     "insertId": "EXTRACT(insertId)",
-    "snapshot_timestamp": "REGEXP_EXTRACT(textPayload, \"Reporting Upload Failure:.*[snapshotTimestamp=(\\\\d+)]\")"
+    "snapshot_timestamp": "REGEXP_EXTRACT(textPayload, \"snapshotTimestamp=(\\\\d+)\")"
   }
 }


### PR DESCRIPTION
Ticket: [RW-16391](https://precisionmedicineinitiative.atlassian.net/browse/RW-16391)
* Add alert `task_failure_reporting_upload.json` which notifies on failed cloud tasks similar to existing Cloud Task alerts.
* Introduce log-based metric using `reporting_upload_failure.json` which will detect the log message introduced in https://github.com/all-of-us/workbench/pull/9386. This metric is used to trigger the alert defined by `logging_last_reporting_snapshot_failure.json`. The idea behind using this log-based metric is that I have low confidence that all WRD upload failures will trigger a failed cloud task. During our last WRD upload incident, it appears that there were nights where the upload did not complete but no cloud tasks failed. Relying on the format of a log message is brittle, but this isn't a vital component of the workbench, so I'm willing to call it good enough (but welcome alternative opinions!). 

Terraform plan output from local
```
Terraform will perform the following actions:

  # module.workbench.module.monitoring.module.alert_policies.google_monitoring_alert_policy.policy["logging_last_reporting_snapshot_failure"] will be created
  + resource "google_monitoring_alert_policy" "policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Upload Reporting Snapshot Failure"
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "all-of-us-workbench-test"

      + alert_strategy {
          + notification_channel_strategy {
              + renotify_interval = "86400s"
            }
        }

      + conditions {
          + display_name = "Upload Reporting Snapshot Failure"
          + name         = (known after apply)

          + condition_threshold {
              + comparison      = "COMPARISON_GT"
              + duration        = "180s"
              + filter          = "metric.type=\"logging.googleapis.com/user/reporting_upload_failure\" resource.type=\"gae_app\""
              + threshold_value = 1

              + aggregations {
                  + alignment_period     = "60s"
                  + cross_series_reducer = "REDUCE_SUM"
                  + per_series_aligner   = "ALIGN_RATE"
                }

              + trigger {
                  + count = 1
                }
            }
        }

      + documentation {
          + content   = <<-EOT
                This job monitors for failed reporting snapshot uploads
            EOT
          + mime_type = "text/markdown"
        }
    }

  # module.workbench.module.monitoring.module.alert_policies.google_monitoring_alert_policy.policy["task_failure_reporting_upload"] will be created
  + resource "google_monitoring_alert_policy" "policy" {
      + combiner        = "OR"
      + creation_record = (known after apply)
      + display_name    = "Cloud Task failure: reportingUploadQueue"
      + enabled         = true
      + id              = (known after apply)
      + name            = (known after apply)
      + project         = "all-of-us-workbench-test"

      + alert_strategy {
          + notification_channel_strategy {
              + renotify_interval = "86400s"
            }
        }

      + conditions {
          + display_name = "Cloud Task failure: reportingUploadQueue"
          + name         = (known after apply)

          + condition_threshold {
              + comparison      = "COMPARISON_GT"
              + duration        = "60s"
              + filter          = "metric.type=\"cloudtasks.googleapis.com/queue/task_attempt_count\" resource.type=\"cloud_tasks_queue\" metric.label.\"response_code\"!=\"ok\" resource.label.\"queue_id\"=\"reportingUploadQueue\""
              + threshold_value = 0

              + aggregations {
                  + alignment_period     = "60s"
                  + cross_series_reducer = "REDUCE_SUM"
                  + per_series_aligner   = "ALIGN_RATE"
                }

              + trigger {
                  + count = 1
                }
            }
        }

      + documentation {
          + content   = "Playbook: https://broad.io/aou-playbook"
          + mime_type = "text/markdown"
        }
    }

  # module.workbench.module.monitoring.module.metric_descriptors.google_logging_metric.logging_metric["reporting_upload_failure"] will be created
  + resource "google_logging_metric" "logging_metric" {
      + description      = "Latest reporting snapshot failures"
      + filter           = <<-EOT
            resource.type="gae_app"
            logName="projects/aou-rw-tf-sandbox-dev/logs/%2Fvar%2Flog%2Fapp"
            textPayload=~"Reporting Upload Failure:.*snapshotTimestamp=(\\d+)"
        EOT
      + id               = (known after apply)
      + label_extractors = {
          + "insertId"           = "EXTRACT(insertId)"
          + "snapshot_timestamp" = "REGEXP_EXTRACT(textPayload, \"Reporting Upload Failure:.*snapshotTimestamp=(\\\\d+)\"))"
        }
      + name             = "reporting_upload_failure"
      + project          = "all-of-us-workbench-test"

      + metric_descriptor {
          + metric_kind = "DELTA"
          + unit        = "1"
          + value_type  = "INT64"

          + labels {
              + description = "Epoch timestamp of the failed reporting snapshot"
              + key         = "snapshot_timestamp"
              + value_type  = "INT64"
            }
          + labels {
              + description = "Insert ID. Useful for finding the log entry later"
              + key         = "insertId"
              + value_type  = "STRING"
            }
        }
    }

Plan: 3 to add, 0 to change, 0 to destroy.
```

[RW-16391]: https://precisionmedicineinitiative.atlassian.net/browse/RW-16391?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ