### PR TITLE
[PD-32645][risk=no] Convert GAR reader IAM to use a list of groups

### DIFF
--- a/modules/workbench/main.tf
+++ b/modules/workbench/main.tf
@@ -26,8 +26,7 @@ module "artifact_registry" {
   source = "./modules/artifact_registry"
   project_id = var.project_id
   aou_env = var.aou_env
-  registered_tier_group_name = var.registered_tier_group_name
-  controlled_tier_group_name = var.controlled_tier_group_name
+  reader_group_names = var.gar_reader_group_names
 }
 
 # Workload Identity

--- a/modules/workbench/modules/artifact_registry/main.tf
+++ b/modules/workbench/modules/artifact_registry/main.tf
@@ -14,18 +14,11 @@ resource "google_artifact_registry_repository" "gar_remote_docker" {
   }
 }
 
-resource "google_artifact_registry_repository_iam_member" "remote_docker_iam-member_rt" {
-  project = google_artifact_registry_repository.gar_remote_docker.project
-  location = google_artifact_registry_repository.gar_remote_docker.location
+resource "google_artifact_registry_repository_iam_member" "remote_docker_reader" {
+  for_each   = toset(var.reader_group_names)
+  project    = google_artifact_registry_repository.gar_remote_docker.project
+  location   = google_artifact_registry_repository.gar_remote_docker.location
   repository = google_artifact_registry_repository.gar_remote_docker.name
-  role = "roles/artifactregistry.reader"
-  member = join("", ["group:", var.registered_tier_group_name])
-}
-
-resource "google_artifact_registry_repository_iam_member" "remote_docker_iam-member_ct" {
-  project = google_artifact_registry_repository.gar_remote_docker.project
-  location = google_artifact_registry_repository.gar_remote_docker.location
-  repository = google_artifact_registry_repository.gar_remote_docker.name
-  role = "roles/artifactregistry.reader"
-  member = join("", ["group:", var.controlled_tier_group_name])
+  role       = "roles/artifactregistry.reader"
+  member     = "group:${each.value}"
 }

--- a/modules/workbench/modules/artifact_registry/variables.tf
+++ b/modules/workbench/modules/artifact_registry/variables.tf
@@ -8,12 +8,7 @@ variable project_id {
   type        = string
 }
 
-variable registered_tier_group_name {
-  description = "Google group that contains all registered tier users"
-  type        = string
-}
-
-variable controlled_tier_group_name {
-  description = "Google group that contains all controlled tier users"
-  type        = string
+variable reader_group_names {
+  description = "Google groups that should have read access to the artifact registry"
+  type        = list(string)
 }

--- a/modules/workbench/variables.tf
+++ b/modules/workbench/variables.tf
@@ -89,14 +89,9 @@ variable alert_thresholds {
   })
 }
 
-variable registered_tier_group_name {
-  description = "Google group that contains all registered tier users"
-  type        = string
-}
-
-variable controlled_tier_group_name {
-  description = "Google group that contains all controlled tier users"
-  type        = string
+variable gar_reader_group_names {
+  description = "Google groups that should have read access to the artifact registry"
+  type        = list(string)
 }
 
 #


### PR DESCRIPTION
## Context
I need to make this a list so that I can add VWB groups here

## Summary
- Replace separate `registered_tier_group_name` and `controlled_tier_group_name` variables with a single `gar_reader_group_names` list variable
- Consolidate two hardcoded IAM member resources into one resource using `for_each`
- Makes it easy to add or remove reader groups without modifying Terraform code

## Test plan
- [ ] `terraform plan` shows expected state moves (old IAM members destroyed, new ones created)
- [ ] Verify GAR read access works for all groups in the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://precisionmedicineinitiative.atlassian.net/browse/PD-32645