### PR TITLE
[DT-1120][risk=no] Updates for workspace reporting schemas

### DIFF
--- a/modules/workbench/modules/reporting/assets/schemas/workspace.json
+++ b/modules/workbench/modules/reporting/assets/schemas/workspace.json
@@ -23,6 +23,12 @@
     "mode": "NULLABLE"
   },
   {
+    "name": "cdr_version_name",
+    "type": "STRING",
+    "description": "Human-readable name of the CDR version.",
+    "mode": "NULLABLE"
+  },
+  {
     "name": "creation_time",
     "type": "TIMESTAMP",
     "description": "Time workspace was initially created.",
@@ -326,6 +332,12 @@
     "name": "migration_state",
     "type": "STRING",
     "description": "Status of the RW 1.0 to VWB migration for this workspace",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "recovery_state",
+    "type": "STRING",
+    "description": "Status of recovering RW 1.0 workspace files into a RW 2.0 workspace",
     "mode": "NULLABLE"
   }
 ]

--- a/modules/workbench/modules/reporting/assets/schemas/workspace_bucket_archive.json
+++ b/modules/workbench/modules/reporting/assets/schemas/workspace_bucket_archive.json
@@ -1,0 +1,31 @@
+[
+  {
+    "description": "Time snapshot was taken, in Epoch milliseconds. Same across all rows and all tables in the snapshot, and uniquely defines a particular snapshot.",
+    "name": "snapshot_timestamp",
+    "type": "INTEGER"
+  },
+  {
+    "name": "legacy_workspace_id",
+    "type": "INTEGER",
+    "description": "Workspace ID of workspace being archived. Join with workspace_id in workspace table to get more information.",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "gcs_path",
+    "type": "STRING",
+    "description": "URL path of the destination folder in the archive bucket",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "created",
+    "type": "TIMESTAMP",
+    "description": "Timestamp the archive was created.",
+    "mode": "NULLABLE"
+  },
+  {
+    "name": "status",
+    "type": "STRING",
+    "description": "Status of the archive.",
+    "mode": "NULLABLE"
+  }
+]


### PR DESCRIPTION
- Add new schema for `workspace_bucket_archive` table
- Add `cdr_version_name` and `recovery_state` columns to `workspace` table schema